### PR TITLE
Add ERC20 Token Support to Hashchain Protocol

### DIFF
--- a/src/MuPay.sol
+++ b/src/MuPay.sol
@@ -184,7 +184,7 @@ contract MuPay is ReentrancyGuard {
             uint256 amountToReclaim = channel.amount;
             delete channelsMapping[msg.sender][merchant];
             (bool sent,) = payable(msg.sender).call{value: amountToReclaim}("");
-            if (sent == false) {
+            if (!sent) {
                 revert FailedToSendEther();
             }
 

--- a/src/MuPay.sol
+++ b/src/MuPay.sol
@@ -2,6 +2,8 @@
 pragma solidity 0.8.28;
 
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 /**
  * @title MuPay - A Simple Payment Channel
@@ -9,10 +11,13 @@ import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol
  * using a hashchain-based verification mechanism to track payments.
  */
 contract MuPay is ReentrancyGuard {
+    using SafeERC20 for IERC20;
     /**
      * @dev Represents a payment channel between a payer and a merchant.
      */
+
     struct Channel {
+        address token; // Token address, address(0) for native currency
         bytes32 trustAnchor; // The initial hash value of the hashchain.
         uint256 amount; // Total deposit in the payment channel.
         uint16 numberOfTokens; // Number of tokens in the hashchain.
@@ -20,8 +25,9 @@ contract MuPay is ReentrancyGuard {
         uint64 payerWithdrawAfterBlocks; // Block number after which the payer can reclaim funds.
     }
 
-    // user -> merchant -> channel
-    mapping(address => mapping(address => Channel)) public channelsMapping;
+    // Updated mapping to include token dimension
+    // user -> merchant -> token -> channel
+    mapping(address => mapping(address => mapping(address => Channel))) public channelsMapping;
 
     /**
      * @dev Custom errors to reduce contract size and improve clarity.
@@ -33,7 +39,7 @@ contract MuPay is ReentrancyGuard {
     error NothingPayable();
     error FailedToSendEther();
     error PayerCannotRedeemChannelYet(uint64 blockNumber);
-    error ChannelAlreadyExist(address payer, address merchant, uint256 amount, uint16 numberOfTokens);
+    error ChannelAlreadyExist(address payer, address merchant, address token, uint256 amount, uint16 numberOfTokens);
     error ZeroTokensNotAllowed();
     error MerchantWithdrawTimeTooShort();
     error TokenCountExceeded(uint256 totalAvailable, uint256 used);
@@ -44,6 +50,7 @@ contract MuPay is ReentrancyGuard {
     event ChannelCreated(
         address indexed payer,
         address indexed merchant,
+        address token,
         uint256 amount,
         uint16 numberOfTokens,
         uint64 merchantWithdrawAfterBlocks
@@ -51,12 +58,13 @@ contract MuPay is ReentrancyGuard {
     event ChannelRedeemed(
         address indexed payer,
         address indexed merchant,
+        address token,
         uint256 amountPaid,
         bytes32 finalHashValue,
         uint16 numberOfTokensUsed
     );
-    event ChannelRefunded(address indexed payer, address indexed merchant, uint256 refundAmount);
-    event ChannelReclaimed(address indexed payer, address indexed merchant, uint64 blockNumber);
+    event ChannelRefunded(address indexed payer, address indexed merchant, address token, uint256 refundAmount);
+    event ChannelReclaimed(address indexed payer, address indexed merchant, address token, uint64 blockNumber);
 
     /**
      * @dev Verifies if the final hash value is valid given a trust anchor and the number of tokens used.
@@ -80,6 +88,7 @@ contract MuPay is ReentrancyGuard {
     /**
      * @dev Creates a new payment channel between a payer and a merchant.
      * @param merchant The merchant receiving payments.
+     * @param token The ERC-20 token address used for payments, or address(0) to use the native currency.
      * @param trustAnchor The starting hash value of the hashchain.
      * @param amount The total deposit amount for the channel.
      * @param numberOfTokens The number of tokens in the hashchain.
@@ -88,6 +97,7 @@ contract MuPay is ReentrancyGuard {
      */
     function createChannel(
         address merchant,
+        address token,
         bytes32 trustAnchor,
         uint256 amount,
         uint16 numberOfTokens,
@@ -95,16 +105,25 @@ contract MuPay is ReentrancyGuard {
         uint64 payerWithdrawAfterBlocks
     ) public payable {
         require(merchant != address(0), "Invalid address");
-        if (msg.value != amount) {
-            revert IncorrectAmount(msg.value, amount);
+
+        if (token == address(0)) {
+            if (msg.value != amount) {
+                revert IncorrectAmount(msg.value, amount);
+            }
+        } else {
+            if (msg.value != 0) {
+                revert IncorrectAmount(msg.value, 0);
+            }
+            IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
         }
 
-        if (channelsMapping[msg.sender][merchant].amount != 0) {
+        if (channelsMapping[msg.sender][merchant][token].amount != 0) {
             revert ChannelAlreadyExist(
                 msg.sender,
                 merchant,
-                channelsMapping[msg.sender][merchant].amount,
-                channelsMapping[msg.sender][merchant].numberOfTokens
+                token,
+                channelsMapping[msg.sender][merchant][token].amount,
+                channelsMapping[msg.sender][merchant][token].numberOfTokens
             );
         }
 
@@ -117,7 +136,8 @@ contract MuPay is ReentrancyGuard {
             revert MerchantWithdrawTimeTooShort();
         }
 
-        channelsMapping[msg.sender][merchant] = Channel({
+        channelsMapping[msg.sender][merchant][token] = Channel({
+            token: token,
             trustAnchor: trustAnchor,
             amount: amount,
             numberOfTokens: numberOfTokens,
@@ -125,18 +145,22 @@ contract MuPay is ReentrancyGuard {
             payerWithdrawAfterBlocks: uint64(block.number) + payerWithdrawAfterBlocks
         });
 
-        emit ChannelCreated(msg.sender, merchant, amount, numberOfTokens, merchantWithdrawAfterBlocks);
+        emit ChannelCreated(msg.sender, merchant, token, amount, numberOfTokens, merchantWithdrawAfterBlocks);
     }
 
     /**
      * @dev Redeems a payment channel by verifying a final hash value.
      * @param payer The address of the payer.
+     * @param token The ERC-20 token address used for payments, or address(0) to use the native currency.
      * @param finalHashValue The final hash value after consuming tokens.
      * @param numberOfTokensUsed The number of tokens used.
      */
-    function redeemChannel(address payer, bytes32 finalHashValue, uint16 numberOfTokensUsed) public nonReentrant {
+    function redeemChannel(address payer, address token, bytes32 finalHashValue, uint16 numberOfTokensUsed)
+        public
+        nonReentrant
+    {
         require(payer != address(0), "Invalid address");
-        Channel storage channel = channelsMapping[payer][msg.sender];
+        Channel storage channel = channelsMapping[payer][msg.sender][token];
         if (channel.amount == 0) {
             revert ChannelDoesNotExistOrWithdrawn();
         }
@@ -158,37 +182,50 @@ contract MuPay is ReentrancyGuard {
         if (payableAmountMerchant == 0) {
             revert NothingPayable();
         }
-        delete channelsMapping[payer][msg.sender];
-        (bool sentMerchant,) = payable(msg.sender).call{value: payableAmountMerchant}("");
-        (bool sentPayer,) = payable(payer).call{value: payableAmountPayer}("");
-        if (!sentMerchant || !sentPayer) {
-            revert FailedToSendEther();
+        delete channelsMapping[payer][msg.sender][token];
+
+        if (token == address(0)) {
+            (bool sentMerchant,) = payable(msg.sender).call{value: payableAmountMerchant}("");
+            (bool sentPayer,) = payable(payer).call{value: payableAmountPayer}("");
+            if (!sentMerchant || !sentPayer) {
+                revert FailedToSendEther();
+            }
+        } else {
+            // ERC-20 token transfer
+            IERC20(token).safeTransfer(msg.sender, payableAmountMerchant);
+            IERC20(token).safeTransfer(payer, payableAmountPayer);
         }
 
-        emit ChannelRedeemed(payer, msg.sender, payableAmountMerchant, finalHashValue, numberOfTokensUsed);
+        emit ChannelRedeemed(payer, msg.sender, token, payableAmountMerchant, finalHashValue, numberOfTokensUsed);
 
-        emit ChannelRefunded(payer, msg.sender, payableAmountPayer);
+        emit ChannelRefunded(payer, msg.sender, token, payableAmountPayer);
     }
 
     /**
      * @dev Allows the payer to reclaim their deposit after the withdrawal period expires.
      * @param merchant The address of the merchant.
+     * @param token The ERC-20 token address used for payments, or address(0) to use the native currency.
      */
-    function reclaimChannel(address merchant) public nonReentrant {
+    function reclaimChannel(address merchant, address token) public nonReentrant {
         require(merchant != address(0), "Invalid address");
-        Channel storage channel = channelsMapping[msg.sender][merchant];
+        Channel storage channel = channelsMapping[msg.sender][merchant][token];
         if (channel.amount == 0) {
             revert ChannelDoesNotExistOrWithdrawn();
         }
         if (channel.payerWithdrawAfterBlocks < block.number) {
             uint256 amountToReclaim = channel.amount;
-            delete channelsMapping[msg.sender][merchant];
-            (bool sent,) = payable(msg.sender).call{value: amountToReclaim}("");
-            if (!sent) {
-                revert FailedToSendEther();
+            delete channelsMapping[msg.sender][merchant][token];
+
+            if (token == address(0)) {
+                (bool sent,) = payable(msg.sender).call{value: amountToReclaim}("");
+                if (!sent) {
+                    revert FailedToSendEther();
+                }
+            } else {
+                IERC20(token).safeTransfer(msg.sender, amountToReclaim);
             }
 
-            emit ChannelReclaimed(msg.sender, merchant, uint64(block.number));
+            emit ChannelReclaimed(msg.sender, merchant, token, uint64(block.number));
         } else {
             revert PayerCannotRedeemChannelYet(channel.payerWithdrawAfterBlocks);
         }

--- a/src/MuPay.sol
+++ b/src/MuPay.sol
@@ -149,7 +149,7 @@ contract MuPay is ReentrancyGuard {
             revert TokenCountExceeded(channel.numberOfTokens, numberOfTokensUsed);
         }
 
-        if (verifyHashchain(channel.trustAnchor, finalHashValue, numberOfTokensUsed) == false) {
+        if (!verifyHashchain(channel.trustAnchor, finalHashValue, numberOfTokensUsed)) {
             revert TokenVerificationFailed();
         }
         uint256 payableAmountMerchant = (channel.amount * numberOfTokensUsed) / channel.numberOfTokens;

--- a/test/CreateChannelERC20.t.sol
+++ b/test/CreateChannelERC20.t.sol
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {Test, console} from "forge-std/Test.sol";
+import {MuPay} from "../src/MuPay.sol";
+import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+
+contract CreateChannelERC20Test is Test {
+    MuPay public muPay;
+    address public payer = address(0x1);
+    address public merchant = address(0x2);
+    ERC20Mock token;
+
+    function setUp() external {
+        muPay = new MuPay();
+        token = new ERC20Mock();
+
+        token.mint(payer, 1000 * 1e18);
+        vm.deal(payer, 1 ether);
+
+        vm.prank(payer);
+        token.approve(address(muPay), 100 * 1e18);
+    }
+
+    function testCreateChannelERC20() public {
+        // Setup parameters
+        bytes32 trustAnchor = 0x7cacb8c6cc65163d30a6c8ce47c0d284490d228d1d1aa7e9ae3f149f77b32b5d;
+        uint256 amount = 1e18;
+        uint16 numberOfTokens = 100;
+        uint64 merchantWithdrawAfterBlocks = uint64(block.number) + 1;
+        uint64 payerWithdrawAfterBlocks = uint64(block.number) + 1;
+
+        // Check balances before transaction
+        uint256 payerBalanceBefore = token.balanceOf(payer);
+        uint256 contractBalanceBefore = token.balanceOf(address(muPay));
+
+        // Expect event emission
+        vm.expectEmit(true, true, false, true);
+        emit MuPay.ChannelCreated(payer, merchant, address(token), amount, numberOfTokens, merchantWithdrawAfterBlocks);
+
+        // Execute the function call
+        vm.prank(payer);
+        muPay.createChannel(
+            merchant,
+            address(token),
+            trustAnchor,
+            amount,
+            numberOfTokens,
+            merchantWithdrawAfterBlocks,
+            payerWithdrawAfterBlocks
+        );
+
+        // Check balances after transaction
+        uint256 payerBalanceAfter = token.balanceOf(payer);
+        uint256 contractBalanceAfter = token.balanceOf(address(muPay));
+
+        // Verify balance deductions
+        assertEq(payerBalanceBefore - payerBalanceAfter, amount, "Incorrect amount deducted from payer");
+        assertEq(contractBalanceAfter - contractBalanceBefore, amount, "Incorrect amount added to contract");
+
+        // Verify storage updates
+        (address storedToken, bytes32 storedTrustAnchor, uint256 storedAmount, uint256 storedNumberOfToken,,) =
+            muPay.channelsMapping(payer, merchant, address(token));
+
+        assertEq(storedToken, address(token), "Incorrect token address stored");
+        assertEq(storedTrustAnchor, trustAnchor, "Incorrect trust anchor stored");
+        assertEq(storedAmount, amount, "Incorrect amount stored");
+        assertEq(storedNumberOfToken, numberOfTokens, "Incorrect number of tokens stored");
+    }
+
+    function testCreateChannelERC20IncorrectAmount() public {
+        // Setup parameters
+        bytes32 trustAnchor = 0x7cacb8c6cc65163d30a6c8ce47c0d284490d228d1d1aa7e9ae3f149f77b32b5d;
+        uint256 amount = 1e18;
+        uint16 numberOfTokens = 100;
+        uint64 merchantWithdrawAfterBlocks = 1;
+        uint64 payerWithdrawAfterBlocks = 1;
+
+        uint256 incorrectAmount = 1e10;
+
+        // Expect revert
+        vm.expectRevert(abi.encodeWithSelector(MuPay.IncorrectAmount.selector, incorrectAmount, 0));
+
+        // Execute the function call
+        vm.prank(payer);
+        muPay.createChannel{value: incorrectAmount}(
+            merchant,
+            address(token),
+            trustAnchor,
+            amount,
+            numberOfTokens,
+            merchantWithdrawAfterBlocks,
+            payerWithdrawAfterBlocks
+        );
+    }
+
+    function testCreateChannelERC20DuplicateCheck() public {
+        // Setup parameters
+        bytes32 trustAnchor = 0x7cacb8c6cc65163d30a6c8ce47c0d284490d228d1d1aa7e9ae3f149f77b32b5d;
+        uint256 amount = 1e18;
+        uint16 numberOfTokens = 100;
+        uint64 merchantWithdrawAfterBlocks = 1;
+        uint64 payerWithdrawAfterBlocks = 1;
+
+        // Execute the function call
+        vm.prank(payer);
+        muPay.createChannel(
+            merchant,
+            address(token),
+            trustAnchor,
+            amount,
+            numberOfTokens,
+            merchantWithdrawAfterBlocks,
+            payerWithdrawAfterBlocks
+        );
+
+        // Expect revert
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                MuPay.ChannelAlreadyExist.selector, payer, merchant, address(token), amount, numberOfTokens
+            )
+        );
+
+        // Execute the function call again
+        vm.prank(payer);
+        muPay.createChannel(
+            merchant,
+            address(token),
+            trustAnchor,
+            amount,
+            numberOfTokens,
+            merchantWithdrawAfterBlocks,
+            payerWithdrawAfterBlocks
+        );
+    }
+
+    function testCreateChannelERC20ZeroToken() public {
+        // Setup parameters
+        bytes32 trustAnchor = 0x7cacb8c6cc65163d30a6c8ce47c0d284490d228d1d1aa7e9ae3f149f77b32b5d;
+        uint256 amount = 1e18;
+        // Set number of token as 0
+        uint16 numberOfTokens = 0;
+        uint64 merchantWithdrawAfterBlocks = 1;
+        uint64 payerWithdrawAfterBlocks = 1;
+
+        vm.expectRevert(MuPay.ZeroTokensNotAllowed.selector);
+
+        // Execute the function call
+        vm.prank(payer);
+        muPay.createChannel(
+            merchant,
+            address(token),
+            trustAnchor,
+            amount,
+            numberOfTokens,
+            merchantWithdrawAfterBlocks,
+            payerWithdrawAfterBlocks
+        );
+    }
+}

--- a/test/ReclaimChannelERC20.t.sol
+++ b/test/ReclaimChannelERC20.t.sol
@@ -12,8 +12,7 @@ contract ReclaimChannelTest is Test {
 
     // Setup parameters
     ERC20Mock token;
-    bytes32 trustAnchor =
-        0x7cacb8c6cc65163d30a6c8ce47c0d284490d228d1d1aa7e9ae3f149f77b32b5d;
+    bytes32 trustAnchor = 0x7cacb8c6cc65163d30a6c8ce47c0d284490d228d1d1aa7e9ae3f149f77b32b5d;
     uint256 amount = 1e18;
     uint16 numberOfTokens = 100;
     uint64 merchantWithdrawAfterBlocks = 10;
@@ -30,14 +29,7 @@ contract ReclaimChannelTest is Test {
 
         // Expect event emission
         vm.expectEmit(true, true, false, true);
-        emit MuPay.ChannelCreated(
-            payer,
-            merchant,
-            address(token),
-            amount,
-            numberOfTokens,
-            merchantWithdrawAfterBlocks
-        );
+        emit MuPay.ChannelCreated(payer, merchant, address(token), amount, numberOfTokens, merchantWithdrawAfterBlocks);
 
         vm.prank(payer);
         muPay.createChannel(
@@ -57,34 +49,21 @@ contract ReclaimChannelTest is Test {
         uint256 payerBalanceBefore = token.balanceOf(payer);
 
         vm.expectEmit(true, true, false, true);
-        emit MuPay.ChannelReclaimed(
-            payer,
-            merchant,
-            address(token),
-            uint64(block.number)
-        );
+        emit MuPay.ChannelReclaimed(payer, merchant, address(token), uint64(block.number));
 
         vm.prank(payer);
         muPay.reclaimChannel(merchant, address(token));
 
         uint256 payerBalanceAfter = token.balanceOf(payer);
 
-        assertEq(
-            payerBalanceAfter - payerBalanceBefore,
-            amount,
-            "Incorrect amount sent to payer"
-        );
+        assertEq(payerBalanceAfter - payerBalanceBefore, amount, "Incorrect amount sent to payer");
     }
 
     function testReclaimERC20BeforeAllowed() public {
-        (, , , , , uint256 storedPayerWithdrawAfterBlocks) = muPay
-            .channelsMapping(payer, merchant, address(token));
+        (,,,,, uint256 storedPayerWithdrawAfterBlocks) = muPay.channelsMapping(payer, merchant, address(token));
 
         vm.expectRevert(
-            abi.encodeWithSelector(
-                MuPay.PayerCannotRedeemChannelYet.selector,
-                storedPayerWithdrawAfterBlocks
-            )
+            abi.encodeWithSelector(MuPay.PayerCannotRedeemChannelYet.selector, storedPayerWithdrawAfterBlocks)
         );
         vm.prank(payer);
         muPay.reclaimChannel(merchant, address(token));

--- a/test/ReclaimChannelERC20.t.sol
+++ b/test/ReclaimChannelERC20.t.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {Test, console} from "forge-std/Test.sol";
+import {MuPay} from "../src/MuPay.sol";
+import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+
+contract ReclaimChannelTest is Test {
+    MuPay public muPay;
+    address public payer = address(0x1);
+    address public merchant = address(0x2);
+
+    // Setup parameters
+    ERC20Mock token;
+    bytes32 trustAnchor =
+        0x7cacb8c6cc65163d30a6c8ce47c0d284490d228d1d1aa7e9ae3f149f77b32b5d;
+    uint256 amount = 1e18;
+    uint16 numberOfTokens = 100;
+    uint64 merchantWithdrawAfterBlocks = 10;
+    uint64 payerWithdrawAfterBlocks = 100;
+
+    function setUp() external {
+        muPay = new MuPay();
+        token = new ERC20Mock();
+        vm.deal(payer, 10 ether);
+
+        token.mint(payer, 1000 * 1e18);
+        vm.prank(payer);
+        token.approve(address(muPay), 100 * 1e18);
+
+        // Expect event emission
+        vm.expectEmit(true, true, false, true);
+        emit MuPay.ChannelCreated(
+            payer,
+            merchant,
+            address(token),
+            amount,
+            numberOfTokens,
+            merchantWithdrawAfterBlocks
+        );
+
+        vm.prank(payer);
+        muPay.createChannel(
+            merchant,
+            address(token),
+            trustAnchor,
+            amount,
+            numberOfTokens,
+            merchantWithdrawAfterBlocks,
+            payerWithdrawAfterBlocks
+        );
+    }
+
+    function testReclaimChannelERC20Success() public {
+        vm.roll(block.number + 101);
+
+        uint256 payerBalanceBefore = token.balanceOf(payer);
+
+        vm.expectEmit(true, true, false, true);
+        emit MuPay.ChannelReclaimed(
+            payer,
+            merchant,
+            address(token),
+            uint64(block.number)
+        );
+
+        vm.prank(payer);
+        muPay.reclaimChannel(merchant, address(token));
+
+        uint256 payerBalanceAfter = token.balanceOf(payer);
+
+        assertEq(
+            payerBalanceAfter - payerBalanceBefore,
+            amount,
+            "Incorrect amount sent to payer"
+        );
+    }
+
+    function testReclaimERC20BeforeAllowed() public {
+        (, , , , , uint256 storedPayerWithdrawAfterBlocks) = muPay
+            .channelsMapping(payer, merchant, address(token));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                MuPay.PayerCannotRedeemChannelYet.selector,
+                storedPayerWithdrawAfterBlocks
+            )
+        );
+        vm.prank(payer);
+        muPay.reclaimChannel(merchant, address(token));
+    }
+
+    function testReclaimERC20NotExistantChannel() public {
+        address merchant2 = address(0x3);
+
+        vm.expectRevert(MuPay.ChannelDoesNotExistOrWithdrawn.selector);
+
+        vm.prank(payer);
+        muPay.reclaimChannel(merchant2, address(token));
+    }
+}

--- a/test/RedeemChannelERC20.t.sol
+++ b/test/RedeemChannelERC20.t.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {Test, console} from "forge-std/Test.sol";
+import {MuPay} from "../src/MuPay.sol";
+import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+
+contract MaliciousReceiver {
+    // Rejects any ETH sent to it
+    fallback() external payable {
+        revert("ETH Transfer Failed");
+    }
+}
+
+contract RedeemChannelTest is Test {
+    MuPay public muPay;
+    address public payer = address(0x1);
+    address public merchant = address(0x2);
+    ERC20Mock token;
+
+    // Setup parameters
+    bytes32 trustAnchor = 0x7cacb8c6cc65163d30a6c8ce47c0d284490d228d1d1aa7e9ae3f149f77b32b5d;
+    bytes32 finalToken = 0x484f839e58e0b400163856f9b4d2c6254e142d89d8b03f1e33a6717620170f30;
+    uint256 amount = 1e18;
+    uint16 numberOfTokens = 100;
+    uint64 merchantWithdrawAfterBlocks = uint64(block.number) + 10;
+    uint64 payerWithdrawAfterBlocks = uint64(block.number) + 100;
+    uint16 numberOfTokensUsed = 50;
+
+    function setUp() external {
+        muPay = new MuPay();
+        vm.deal(payer, 10 ether);
+
+        token = new ERC20Mock();
+        token.mint(payer, 1000 * 1e18);
+        vm.prank(payer);
+        token.approve(address(muPay), 100 * 1e18);
+
+        // Expect event emission
+        vm.expectEmit(true, true, false, true);
+        emit MuPay.ChannelCreated(payer, merchant, address(token), amount, numberOfTokens, merchantWithdrawAfterBlocks);
+
+        vm.prank(payer);
+        muPay.createChannel(
+            merchant,
+            address(token),
+            trustAnchor,
+            amount,
+            numberOfTokens,
+            merchantWithdrawAfterBlocks,
+            payerWithdrawAfterBlocks
+        );
+    }
+
+    function testRedeemChannelERC20Success() public {
+        // Move forward by 11 block
+        vm.roll(block.number + 11);
+
+        (,, uint256 storedAmount, uint256 storedNumberOfToken,,) =
+            muPay.channelsMapping(payer, merchant, address(token));
+
+        uint256 payableAmountMerchant = (storedAmount * numberOfTokensUsed) / storedNumberOfToken;
+        uint256 payableAmountPayer = storedAmount - payableAmountMerchant;
+
+        uint256 payerBalanceBefore = token.balanceOf(payer);
+        uint256 contractBalanceBefore = token.balanceOf(address(muPay));
+        uint256 merchantBalanceBefore = token.balanceOf(merchant);
+
+        vm.expectEmit(true, true, false, true);
+        emit MuPay.ChannelRedeemed(
+            payer, merchant, address(token), payableAmountMerchant, finalToken, numberOfTokensUsed
+        );
+
+        vm.expectEmit(true, true, false, true);
+        emit MuPay.ChannelRefunded(payer, merchant, address(token), payableAmountPayer);
+
+        vm.prank(merchant);
+        muPay.redeemChannel(payer, address(token), finalToken, numberOfTokensUsed);
+
+        // Check balances after transaction
+        uint256 payerBalanceAfter = token.balanceOf(payer);
+        uint256 contractBalanceAfter = token.balanceOf(address(muPay));
+        uint256 merchantBalanceAfter = token.balanceOf(merchant);
+
+        // Verify balance deductions
+        assertEq(payerBalanceAfter - payerBalanceBefore, payableAmountPayer, "Incorrect amount refunded to payer");
+        assertEq(contractBalanceBefore - contractBalanceAfter, amount, "Incorrect amount deducted from contract");
+        assertEq(
+            merchantBalanceAfter - merchantBalanceBefore, payableAmountMerchant, "Incorrect amount added to merchant"
+        );
+
+        (,, uint256 retrievedAmount,,,) = muPay.channelsMapping(payer, merchant, address(token));
+        assertEq(retrievedAmount, 0, "Channel should be deleted after redeeming");
+    }
+
+    function testRedeemERC20BeforeAllowedBlocks() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(MuPay.MerchantCannotRedeemChannelYet.selector, merchantWithdrawAfterBlocks + 1)
+        );
+
+        vm.prank(merchant);
+        muPay.redeemChannel(payer, address(token), finalToken, numberOfTokensUsed);
+    }
+}


### PR DESCRIPTION
### PR Description

This PR closes issue #5 

## Summary

This PR enhances the Hashchain Protocol by adding support for ERC20 tokens alongside native currency. It enables payments using stablecoins like USDT and USDC, improving flexibility and usability of the protocol.


## Implementation

- Mapping Update: Changed channel structure from: `mapping(payer => merchant => channel)` → to:
`mapping(payer => merchant => token => channel)`.
- Function Enhancements:
     - Added a token address parameter to all relevant functions (`createChannel`, `redeemChannel`, `reclaimChannel`).
     - Used address(0) as the standard for native currency on the respective chain.
- ERC20 Integration:
     - Imported IERC20 and used OpenZeppelin’s SafeERC20 for secure token transfers.
     - Handled token vs native transfers conditionally based on `token` address.
- Tests Updated: Extended existing test suite to cover ERC20 token flows using mock tokens.


## Security & Validation

- Maintained reentrancy protection on `redeemChannel` and `reclaimChannel`.
- Used SafeERC20 to securely handle ERC20 transfers, with no additional token validation added at this stage.


## Benefits

- Enables use of popular stablecoins like USDT and USDC.
- Makes the protocol more flexible and appealing to a wider user base.
- Lays groundwork for future multi-token support and integrations.