### PR TITLE
Feature: Add ERC20 allowance check with custom error

### DIFF
--- a/src/MuPay.sol
+++ b/src/MuPay.sol
@@ -43,6 +43,7 @@ contract MuPay is ReentrancyGuard {
     error ZeroTokensNotAllowed();
     error MerchantWithdrawTimeTooShort();
     error TokenCountExceeded(uint256 totalAvailable, uint256 used);
+    error InsufficientAllowance(uint256 required, uint256 actual);
 
     /**
      * @dev Events to log key contract actions.
@@ -113,6 +114,10 @@ contract MuPay is ReentrancyGuard {
         } else {
             if (msg.value != 0) {
                 revert IncorrectAmount(msg.value, 0);
+            }
+            uint256 allowance = IERC20(token).allowance(msg.sender, address(this));
+            if (allowance < amount) {
+                revert InsufficientAllowance(amount, allowance);
             }
             IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
         }

--- a/test/CreateChannelERC20.t.sol
+++ b/test/CreateChannelERC20.t.sol
@@ -157,4 +157,29 @@ contract CreateChannelERC20Test is Test {
             payerWithdrawAfterBlocks
         );
     }
+
+    function testCreateChannelERC20InsufficientAllowance() public {
+        // Setup parameters
+        bytes32 trustAnchor = 0x7cacb8c6cc65163d30a6c8ce47c0d284490d228d1d1aa7e9ae3f149f77b32b5d;
+        uint256 amount = 101 * 1e18;
+        uint16 numberOfTokens = 100;
+        uint64 merchantWithdrawAfterBlocks = uint64(block.number) + 1;
+        uint64 payerWithdrawAfterBlocks = uint64(block.number) + 1;
+        uint256 allowance = token.allowance(payer, address(muPay));
+
+        // Expect revert
+        vm.expectRevert(abi.encodeWithSelector(MuPay.InsufficientAllowance.selector, amount, allowance));
+
+        // Execute the function call
+        vm.prank(payer);
+        muPay.createChannel(
+            merchant,
+            address(token),
+            trustAnchor,
+            amount,
+            numberOfTokens,
+            merchantWithdrawAfterBlocks,
+            payerWithdrawAfterBlocks
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Adds an explicit check for ERC20 allowance before `safeTransferFrom` in `createChannel`. Uses a custom error for clarity and gas savings.

## Changes

- Added `InsufficientAllowance(required, actual)` error
- Fails early if `allowance` < `amount`
- Added test: `testCreateChannelERC20InsufficientAllowance`

Closes Issue #11 