### PR TITLE
Feat: Add Multisig Payment Channel Support

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -2,6 +2,7 @@
 src = "src"
 out = "out"
 libs = ["lib"]
+solc="0.8.30"
 optimizer = true
 optimizer_runs = 200
 via_ir = true

--- a/script/MuPay.s.sol
+++ b/script/MuPay.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.28;
+pragma solidity ^0.8.28;
 
 import {Script} from "forge-std/Script.sol";
 import {MuPay} from "../src/MuPay.sol";

--- a/src/MuPay.sol
+++ b/src/MuPay.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.28;
+pragma solidity ^0.8.28;
 
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";

--- a/src/Multisig_2of2.sol
+++ b/src/Multisig_2of2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.28;
+pragma solidity ^0.8.28;
 
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
@@ -80,6 +80,7 @@ contract Multisig is ReentrancyGuard {
     function createChannel(address payee, address token, uint256 amount, uint64 duration, uint64 reclaimDelay)
         external
         payable
+        nonReentrant
     {
         // Validate payee address
         require(payee != address(0), "Invalid address");

--- a/src/Multisig_2of2.sol
+++ b/src/Multisig_2of2.sol
@@ -159,6 +159,14 @@ contract Multisig is ReentrancyGuard {
         emit ChannelCreated(payer, payee, token, amount, channel.expiration, channel.sessionId);
     }
 
+    /**
+     * @dev Redeems a payment channel by verifying a final signature.
+     * @param payer The address of the payer.
+     * @param token The ERC-20 token address used for payments, or address(0) to use the native currency.
+     * @param amount The amount the payee is claiming from the channel.
+     * @param nounce A strictly increasing number to prevent replay of old vouchers.
+     * @param signature The payer’s EIP-191 signature over the channel settlement parameters.
+     */
     function redeemChannel(address payer, address token, uint256 amount, uint256 nounce, bytes calldata signature)
         external
         nonReentrant

--- a/src/Multisig_2of2.sol
+++ b/src/Multisig_2of2.sol
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+contract Multisig is ReentrancyGuard {
+    using ECDSA for bytes32; // for recover()
+    using MessageHashUtils for bytes32; // for toEthSignedMessageHash()
+    using SafeERC20 for IERC20;
+
+    /**
+     * @dev Represents a payment channel between a payer and a merchant.
+     */
+    struct Channel {
+        address token; // Token address, address(0) for native currency
+        uint256 amount; // Total deposit in the payment channel
+        uint64 expiration; // Block timestamp after which the channel expires and payer can reclaim amount
+        uint64 sessionId; // Unique identifier for the payment session
+        uint256 lastNounce; // Last used nonce to prevent replay attacks and ensure order
+    }
+
+    // payer => payee => token => Channel
+    mapping(address => mapping(address => mapping(address => Channel))) public channels;
+
+    /**
+     * @dev Custom errors to reduce contract size and improve clarity.
+     */
+    error IncorrectAmount(uint256 sentAmount, uint256 expectedAmount);
+    error ChannelDoesNotExistOrWithdrawn();
+    error ChannelExpired(uint64 expiration);
+    error PayerCannotRedeemChannelYet(uint256 blockNumber);
+    error ChannelAlreadyExist(address payer, address payee, address token, uint256 amount);
+    error NothingPayable();
+    error FailedToSendEther();
+    error ZeroTokensNotAllowed();
+    error AddressIsNotContract(address token);
+    error AddressIsNotERC20(address token);
+    error InsufficientAllowance(uint256 required, uint256 actual);
+    error StaleNonce(uint256 supplied, uint256 current);
+    error InvalidChannelSignature(address recovered, address expected);
+
+    /**
+     * @dev Events to log key contract actions.
+     */
+    event ChannelCreated(
+        address indexed payer,
+        address indexed payee,
+        address indexed token,
+        uint256 amount,
+        uint64 expiration,
+        uint256 sessionId
+    );
+    event ChannelRedeemed(
+        address indexed payer,
+        address indexed payee,
+        address indexed token,
+        uint256 amount,
+        uint256 nounce,
+        uint256 sessionId
+    );
+    event ChannelRefunded(address indexed payer, address indexed payee, address indexed token, uint256 refundAmount);
+    event ChannelReclaimed(
+        address indexed payer, address indexed payee, address indexed token, uint256 reclaimedAmount
+    );
+
+    /**
+     * @dev Creates a new payment channel between a payer and a payee.
+     * @param payee The address receiving payments.
+     * @param token The ERC-20 token address used for payments, or address(0) to use the native currency.
+     * @param amount The total deposit amount for the channel.
+     * @param duration The channel lifetime in blocks (from current block).
+     */
+    function createChannel(address payee, address token, uint256 amount, uint64 duration) external payable {
+        // Validate payee address
+        require(payee != address(0), "Invalid address");
+
+        // Dispatch to the correct internal handler based on token type
+        if (token == address(0)) {
+            _createNativeChannel(payee, amount, duration);
+        } else {
+            _createERC20Channel(payee, token, amount, duration);
+        }
+    }
+
+    /**
+     * @dev Handles channel creation when using native currency (ETH).
+     * @param payee The address receiving ETH payments.
+     * @param amount The exact ETH amount to lock in the channel.
+     * @param duration Lifetime of the channel in blocks.
+     */
+    function _createNativeChannel(address payee, uint256 amount, uint64 duration) internal {
+        // Ensure the ETH sent matches the declared deposit
+        if (msg.value != amount) revert IncorrectAmount(msg.value, amount);
+
+        // Initialize and record the channel
+        _initChannel(msg.sender, payee, address(0), amount, duration);
+    }
+
+    /**
+     * @dev Handles channel creation when using an ERC-20 token.
+     * @param payee The address receiving token payments.
+     * @param token The ERC-20 token contract address.
+     * @param amount The token amount to lock in the channel.
+     * @param duration Lifetime of the channel in blocks.
+     */
+    function _createERC20Channel(address payee, address token, uint256 amount, uint64 duration) internal {
+        // Ensure no ETH was sent for token-based payments
+        if (msg.value != 0) revert IncorrectAmount(msg.value, 0);
+
+        // Validate that the token address is a deployed contract
+        if (token.code.length == 0) revert AddressIsNotContract(token);
+
+        // Try calling a common ERC20 function to verify interface compliance
+        // Using totalSupply() as a lightweight sanity check for ERC20 compatibility
+        try IERC20(token).totalSupply() returns (uint256) {
+            // Call succeeded — it's likely an ERC20 token.
+        } catch {
+            revert AddressIsNotERC20(token);
+        }
+
+        // Check that the contract has been approved to spend the specified token amount
+        uint256 allowance = IERC20(token).allowance(msg.sender, address(this));
+        if (allowance < amount) revert InsufficientAllowance(amount, allowance);
+
+        // Pull tokens from payer into this contract
+        IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
+
+        // Initialize and record the channel
+        _initChannel(msg.sender, payee, token, amount, duration);
+    }
+
+    /**
+     * @dev Initializes the channel record and prevents duplicates.
+     * @param payer The address opening the channel.
+     * @param payee The address receiving payments.
+     * @param token The token used (address(0) for ETH).
+     * @param amount The locked deposit amount.
+     * @param duration Number of blocks until expiration.
+     */
+    function _initChannel(address payer, address payee, address token, uint256 amount, uint64 duration) private {
+        // Channel initialization
+        Channel storage channel = channels[payer][payee][token];
+
+        // Prevent channel overwrite
+        if (channel.amount != 0) {
+            revert ChannelAlreadyExist(payer, payee, token, channel.amount);
+        }
+
+        channel.token = token;
+        channel.amount = amount;
+        channel.expiration = uint64(block.number) + duration;
+        channel.sessionId += 1;
+        channel.lastNounce = 0;
+
+        emit ChannelCreated(payer, payee, token, amount, channel.expiration, channel.sessionId);
+    }
+
+    function redeemChannel(address payer, address token, uint256 amount, uint256 nounce, bytes calldata signature)
+        external
+        nonReentrant
+    {
+        // Validate, mark consumed and compute refund
+        (uint256 refund, uint64 sessionId) = _validateAndConsume(payer, msg.sender, token, amount, nounce, signature);
+
+        // Dispatch the two transfers via _transfer helper function
+        _transfer(msg.sender, token, amount);
+        _transfer(payer, token, refund);
+
+        // Emit both events
+        emit ChannelRedeemed(payer, msg.sender, token, amount, nounce, sessionId);
+        emit ChannelRefunded(payer, msg.sender, token, refund);
+    }
+
+    function _validateAndConsume(
+        address payer,
+        address payee,
+        address token,
+        uint256 amount,
+        uint256 nounce,
+        bytes calldata signature
+    ) internal returns (uint256 refund, uint64 sessionId) {
+        Channel storage channel = channels[payer][payee][token];
+        if (channel.amount == 0) revert ChannelDoesNotExistOrWithdrawn();
+        if (block.timestamp > channel.expiration) revert ChannelExpired(channel.expiration);
+        if (amount > channel.amount) revert IncorrectAmount(amount, channel.amount);
+        if (nounce <= channel.lastNounce) revert StaleNonce(nounce, channel.lastNounce);
+
+        // recreate EIP-191 hash
+        bytes32 hash = keccak256(
+            abi.encodePacked(address(this), payer, payee, channel.token, amount, nounce, channel.sessionId)
+        ).toEthSignedMessageHash();
+
+        // signature check
+        address signer = hash.recover(signature);
+        if (signer != payer) revert InvalidChannelSignature(signer, payer);
+
+        // compute refund before zeroing out amount
+        refund = channel.amount - amount;
+        sessionId = channel.sessionId;
+
+        // mark nounce used and clear channel
+        channel.lastNounce = nounce;
+        channel.amount = 0;
+    }
+
+    function _transfer(address recipient, address token, uint256 amount) internal {
+        if (token == address(0)) {
+            (bool ok,) = payable(recipient).call{value: amount}("");
+            if (!ok) revert FailedToSendEther();
+        } else {
+            IERC20(token).safeTransfer(recipient, amount);
+        }
+    }
+}

--- a/test/CreateChannel.t.sol
+++ b/test/CreateChannel.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.28;
+pragma solidity ^0.8.28;
 
 import {Test, console} from "forge-std/Test.sol";
 import {MuPay} from "../src/MuPay.sol";

--- a/test/CreateChannelERC20.t.sol
+++ b/test/CreateChannelERC20.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.28;
+pragma solidity ^0.8.28;
 
 import {Test, console} from "forge-std/Test.sol";
 import {MuPay} from "../src/MuPay.sol";

--- a/test/ReclaimChannel.t.sol
+++ b/test/ReclaimChannel.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.28;
+pragma solidity ^0.8.28;
 
 import {Test, console} from "forge-std/Test.sol";
 import {MuPay} from "../src/MuPay.sol";

--- a/test/ReclaimChannelERC20.t.sol
+++ b/test/ReclaimChannelERC20.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.28;
+pragma solidity ^0.8.28;
 
 import {Test, console} from "forge-std/Test.sol";
 import {MuPay} from "../src/MuPay.sol";

--- a/test/RedeemChannel.t.sol
+++ b/test/RedeemChannel.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.28;
+pragma solidity ^0.8.28;
 
 import {Test, console} from "forge-std/Test.sol";
 import {MuPay} from "../src/MuPay.sol";

--- a/test/RedeemChannelERC20.t.sol
+++ b/test/RedeemChannelERC20.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.28;
+pragma solidity ^0.8.28;
 
 import {Test, console} from "forge-std/Test.sol";
 import {MuPay} from "../src/MuPay.sol";

--- a/test/VerifyHashchain.t.sol
+++ b/test/VerifyHashchain.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.28;
+pragma solidity ^0.8.28;
 
 import {Test, console} from "forge-std/Test.sol";
 import {MuPay} from "../src/MuPay.sol";
@@ -33,7 +33,7 @@ contract VerifyHashchainTest is Test {
         assertEq(false, isValid, "Hashchain with wrong trust anchor should be invalid");
     }
 
-    function testInvalidHashchainWrongDepth() public {
+    function testInvalidHashchainWrongDepth() public view {
         bytes32 finalHash = keccak256(abi.encode("seed"));
         uint16 depth = 100;
         bytes32 trustAnchor = finalHash;

--- a/test/helper/BaseTestHelper.sol
+++ b/test/helper/BaseTestHelper.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {Test, console} from "forge-std/Test.sol";
+
+contract BaseTestHelper is Test {
+    uint256 PAYER1PK = 1;
+    uint256 PAYER2PK = 2;
+    uint256 PAYEE1PK = 3;
+    uint256 PAYEE2PK = 4;
+    uint256 OWNERPK = 5;
+
+    address public immutable PAYER = vm.addr(PAYER1PK);
+    address public immutable PAYER2 = vm.addr(PAYER2PK);
+    address public immutable PAYEE = vm.addr(PAYEE1PK);
+    address public immutable PAYEE2 = vm.addr(PAYEE2PK);
+    address public immutable OWNER = vm.addr(OWNERPK);
+
+    address public NATIVE_TOKEN = address(0);
+    uint64 public constant DURATION = 100;
+    uint64 public constant RECLAIM_DELAY = 1000;
+    uint256 public constant INITIAL_BALANCE = 100 ether;
+    uint256 public constant DEPOSIT_AMOUNT = 10 ether;
+}

--- a/test/multisig/CreateChannel.t.sol
+++ b/test/multisig/CreateChannel.t.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.28;
+pragma solidity ^0.8.28;
 
 import {Test, console} from "forge-std/Test.sol";
 import {Multisig} from "../../src/Multisig_2of2.sol";
+import {BaseTestHelper} from "../helper/BaseTestHelper.sol";
 
 contract CreateChannelTest is Test {
     Multisig multisig;
@@ -93,7 +94,7 @@ contract CreateChannelTest is Test {
     }
 
     // Helper function to check channel not created
-    function _assertChannelNotCreated() private {
+    function _assertChannelNotCreated() private view {
         (
             address channelToken,
             uint256 channelAmount,
@@ -103,11 +104,11 @@ contract CreateChannelTest is Test {
             uint256 lastNounce
         ) = multisig.channels(payer, payee, address(0));
 
-        assertEq(channelToken, address(0));
-        assertEq(channelAmount, 0);
-        assertEq(channelExpiration, 0);
-        assertEq(sessionId, 0);
-        assertEq(reclaimAfter, 0);
-        assertEq(lastNounce, 0);
+        assertEq(channelToken, address(0), "default address should be zero address");
+        assertEq(channelAmount, 0, "default amount should be zero");
+        assertEq(channelExpiration, 0, "default expiration should be zero");
+        assertEq(sessionId, 0, "default sessionId should be zero");
+        assertEq(reclaimAfter, 0, "default reclaimAfter should be zero");
+        assertEq(lastNounce, 0, "default lastNounce should be zero");
     }
 }

--- a/test/multisig/CreateChannel.t.sol
+++ b/test/multisig/CreateChannel.t.sol
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Test, console} from "forge-std/Test.sol";
+import {Multisig} from "../../src/Multisig_2of2.sol";
+
+contract CreateChannelTest is Test {
+    Multisig multisig;
+    address payer = address(0x1);
+    address payee = address(0x2);
+    address token = address(0x3);
+    uint256 amount = 1000;
+    uint64 duration = 100;
+    uint64 reclaimDelay = 200;
+
+    function setUp() public {
+        multisig = new Multisig();
+        vm.deal(payer, 10 * amount);
+    }
+
+    function testMultisigCreateChannelWithNative() public {
+        vm.startPrank(payer);
+        multisig.createChannel{value: amount}(payee, address(0), amount, duration, reclaimDelay);
+        vm.stopPrank();
+
+        // Verify channel creation
+        (
+            address channelToken,
+            uint256 channelAmount,
+            uint64 channelExpiration,
+            uint64 reclaimAfter,
+            uint256 sessionId,
+            uint256 lastNounce
+        ) = multisig.channels(payer, payee, address(0));
+        assertEq(channelToken, address(0));
+        assertEq(channelAmount, amount);
+        assertEq(channelExpiration, uint64(block.timestamp) + duration);
+        assertEq(sessionId, 1);
+        assertEq(reclaimAfter, uint64(block.timestamp) + reclaimDelay);
+        assertEq(lastNounce, 1);
+    }
+
+    function testMultisigCreateChannelFailsIfReclaimTooSoon() public {
+        vm.startPrank(payer);
+        vm.expectRevert(
+            abi.encodeWithSignature(
+                "ReclaimAfterMustBeAfterExpiration(uint64,uint64)", block.timestamp + duration, block.timestamp + 0
+            )
+        );
+        multisig.createChannel{value: amount}(payee, address(0), amount, duration, 0);
+        vm.stopPrank();
+
+        _assertChannelNotCreated();
+    }
+
+    function testMultisigCreateChannelFailsIfAmountIncorrect() public {
+        vm.startPrank(payer);
+        vm.expectRevert(abi.encodeWithSignature("IncorrectAmount(uint256,uint256)", amount, amount + 1));
+        multisig.createChannel{value: amount}(payee, address(0), amount + 1, duration, reclaimDelay);
+        vm.stopPrank();
+
+        _assertChannelNotCreated();
+    }
+
+    function testMultisigCreateChannelsFailsIfDuplicate() public {
+        vm.startPrank(payer);
+        multisig.createChannel{value: amount}(payee, address(0), amount, duration, reclaimDelay);
+        vm.expectRevert(
+            abi.encodeWithSignature(
+                "ChannelAlreadyExist(address,address,address,uint256)", payer, payee, address(0), amount
+            )
+        );
+        amount += 1; // Change amount to trigger revert
+        multisig.createChannel{value: amount}(payee, address(0), amount, duration, reclaimDelay);
+        amount -= 1; // Reset amount for next tests
+        vm.stopPrank();
+
+        // Verify channel have initial values (amount)
+        (
+            address channelToken,
+            uint256 channelAmount,
+            uint64 channelExpiration,
+            uint64 reclaimAfter,
+            uint256 sessionId,
+            uint256 lastNounce
+        ) = multisig.channels(payer, payee, address(0));
+        assertEq(channelToken, address(0), "Channel should use native ETH (zero address)");
+        assertEq(channelAmount, amount, "Channel amount should match the deposit");
+        assertEq(channelExpiration, uint64(block.timestamp) + duration, "Expiration not set correctly");
+        assertEq(reclaimAfter, uint64(block.timestamp) + reclaimDelay, "ReclaimAfter not set correctly");
+        assertEq(sessionId, 1, "SessionId should start at 1");
+        assertEq(lastNounce, 1, "LastNonce should start at 1");
+    }
+
+    // Helper function to check channel not created
+    function _assertChannelNotCreated() private {
+        (
+            address channelToken,
+            uint256 channelAmount,
+            uint64 channelExpiration,
+            uint64 reclaimAfter,
+            uint256 sessionId,
+            uint256 lastNounce
+        ) = multisig.channels(payer, payee, address(0));
+
+        assertEq(channelToken, address(0));
+        assertEq(channelAmount, 0);
+        assertEq(channelExpiration, 0);
+        assertEq(sessionId, 0);
+        assertEq(reclaimAfter, 0);
+        assertEq(lastNounce, 0);
+    }
+}

--- a/test/multisig/ReclaimChannel.t.sol
+++ b/test/multisig/ReclaimChannel.t.sol
@@ -75,13 +75,13 @@ contract ReclaimChannelTest is Test, BaseTestHelper {
 
     function _assertChannelStateWhenFailedReclaim(
         uint256 contractBalanceBefore,
-        uint256 payeeBalanceBefore,
+        uint256 payerBalanceBefore,
         uint256 contractBalanceAfter,
-        uint256 payeeBalanceAfter
+        uint256 payerBalanceAfter
     ) internal pure {
         assertEq(
             contractBalanceAfter, contractBalanceBefore, "contract balance should remain unchanged after failed redeem"
         );
-        assertEq(payeeBalanceAfter, payeeBalanceBefore, "payee balance should remain unchanged after failed redeem");
+        assertEq(payerBalanceAfter, payerBalanceBefore, "payer balance should remain unchanged after failed redeem");
     }
 }

--- a/test/multisig/ReclaimChannel.t.sol
+++ b/test/multisig/ReclaimChannel.t.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.28;
+
+import {Test, console} from "forge-std/Test.sol";
+import {Multisig} from "../../src/Multisig_2of2.sol";
+import {BaseTestHelper} from "../helper/BaseTestHelper.sol";
+
+contract ReclaimChannelTest is Test, BaseTestHelper {
+    Multisig public multisig;
+
+    function setUp() public {
+        setUpNativeTokenWithCreateChannel();
+    }
+
+    function setUpNativeToken() public {
+        vm.startPrank(OWNER);
+        multisig = new Multisig();
+        vm.stopPrank();
+        vm.deal(PAYER, INITIAL_BALANCE);
+        vm.deal(PAYER2, INITIAL_BALANCE);
+    }
+
+    function setUpNativeTokenWithCreateChannel() public {
+        setUpNativeToken();
+        vm.startPrank(PAYER);
+        multisig.createChannel{value: DEPOSIT_AMOUNT}(PAYEE, NATIVE_TOKEN, DEPOSIT_AMOUNT, DURATION, RECLAIM_DELAY);
+        vm.stopPrank();
+    }
+
+    function testMultisigReclaimChannelWithNativeToken() public {
+        uint256 contractBalanceBefore = address(multisig).balance;
+        uint256 payerBalanceBefore = PAYER.balance;
+        vm.warp(block.timestamp + RECLAIM_DELAY + 1); // Move time forward to allow reclaim
+        vm.startPrank(PAYER);
+        multisig.reclaimChannel(PAYEE, NATIVE_TOKEN);
+        vm.stopPrank();
+
+        uint256 contractBalanceAfter = address(multisig).balance;
+        uint256 payerBalanceAfter = PAYER.balance;
+
+        assertEq(
+            contractBalanceAfter, contractBalanceBefore - DEPOSIT_AMOUNT, "Incorrect contract balance after reclaim"
+        );
+        assertEq(payerBalanceAfter - payerBalanceBefore, DEPOSIT_AMOUNT, "Incorrect amount sent to payer");
+    }
+
+    function testMultipleReclaimChannelTooEarlyRevert() public {
+        uint256 contractBalanceBefore = address(multisig).balance;
+        uint256 payerBalanceBefore = PAYER.balance;
+        vm.warp(block.timestamp + RECLAIM_DELAY - 10); // Move time forward but not enough to allow reclaim
+        vm.startPrank(PAYER);
+        vm.expectRevert(
+            abi.encodeWithSignature("PayerCannotRedeemChannelYet(uint256,uint256)", block.timestamp, RECLAIM_DELAY + 1)
+        );
+        multisig.reclaimChannel(PAYEE, NATIVE_TOKEN);
+        vm.stopPrank();
+
+        _assertChannelStateWhenFailedReclaim(
+            contractBalanceBefore, payerBalanceBefore, address(multisig).balance, PAYER.balance
+        );
+    }
+
+    function testMultipleNonExistentChannelReclaim() public {
+        uint256 contractBalanceBefore = address(multisig).balance;
+        uint256 payerBalanceBefore = PAYER.balance;
+        vm.startPrank(PAYER);
+        vm.expectRevert(abi.encodeWithSignature("ChannelDoesNotExistOrWithdrawn()"));
+        multisig.reclaimChannel(PAYEE2, NATIVE_TOKEN); // PAYEE2 has no channel with PAYER
+        vm.stopPrank();
+
+        _assertChannelStateWhenFailedReclaim(
+            contractBalanceBefore, payerBalanceBefore, address(multisig).balance, PAYER.balance
+        );
+    }
+
+    function _assertChannelStateWhenFailedReclaim(
+        uint256 contractBalanceBefore,
+        uint256 payeeBalanceBefore,
+        uint256 contractBalanceAfter,
+        uint256 payeeBalanceAfter
+    ) internal pure {
+        assertEq(
+            contractBalanceAfter, contractBalanceBefore, "contract balance should remain unchanged after failed redeem"
+        );
+        assertEq(payeeBalanceAfter, payeeBalanceBefore, "payee balance should remain unchanged after failed redeem");
+    }
+}

--- a/test/multisig/RedeemChannel.t.sol
+++ b/test/multisig/RedeemChannel.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Test, console} from "forge-std/Test.sol";
+import {Multisig} from "../../src/Multisig_2of2.sol";
+
+contract RedeemChannelTest is Test {
+    Multisig multisig;
+    address payer = address(0x1);
+    address payee = address(0x2);
+    address token = address(0); // native ETH
+    uint256 amount = 1000;
+    uint64 duration = 100;
+    uint64 reclaimDelay = 200;
+
+    function setUp() public {
+        multisig = new Multisig();
+        vm.deal(payer, 10 * amount);
+
+        // Payer creates channel
+        vm.startPrank(payer);
+        multisig.createChannel{value: amount}(payee, address(0), amount, duration, reclaimDelay);
+        vm.stopPrank();
+    }
+}

--- a/test/multisig/RedeemChannel.t.sol
+++ b/test/multisig/RedeemChannel.t.sol
@@ -106,7 +106,7 @@ contract RedeemChannelTest is Test, BaseTestHelper {
         vm.stopPrank();
     }
 
-    function testsMultisigCannotRedeemWithIncorrectAmountHigher() public {
+    function testMultisigCannotRedeemWithIncorrectAmountHigher() public {
         uint256 contractBalanceBefore = address(multisig).balance;
         uint256 payeeBalanceBefore = PAYEE.balance;
         vm.startPrank(PAYEE);

--- a/test/multisig/RedeemChannel.t.sol
+++ b/test/multisig/RedeemChannel.t.sol
@@ -96,7 +96,7 @@ contract RedeemChannelTest is Test, BaseTestHelper {
         (,,,, uint64 sessionId, uint256 lastNonce) = multisig.channels(PAYER, PAYEE, NATIVE_TOKEN);
         bytes memory signature =
             getSignature(address(multisig), PAYER1PK, PAYEE, NATIVE_TOKEN, DEPOSIT_AMOUNT, lastNonce + 1, sessionId);
-        (,,uint64 expiration,,,) = multisig.channels(PAYER, PAYEE, NATIVE_TOKEN);
+        (,, uint64 expiration,,,) = multisig.channels(PAYER, PAYEE, NATIVE_TOKEN);
         vm.warp(expiration + 1); // Move time past expiration
 
         vm.startPrank(PAYEE);
@@ -148,8 +148,7 @@ contract RedeemChannelTest is Test, BaseTestHelper {
         uint256 contractBalanceBefore = address(multisig).balance;
         uint256 payeeBalanceBefore = PAYEE.balance;
         vm.startPrank(PAYEE);
-        bytes memory signature =
-            getSignature(address(multisig), PAYER2PK, PAYEE, NATIVE_TOKEN, DEPOSIT_AMOUNT, 1, 1);
+        bytes memory signature = getSignature(address(multisig), PAYER2PK, PAYEE, NATIVE_TOKEN, DEPOSIT_AMOUNT, 1, 1);
 
         // Attempt to redeem a channel that does not exist
         vm.expectRevert(abi.encodeWithSignature("ChannelDoesNotExistOrWithdrawn()"));
@@ -171,7 +170,7 @@ contract RedeemChannelTest is Test, BaseTestHelper {
             getSignature(address(multisig), PAYER1PK, PAYEE, NATIVE_TOKEN, DEPOSIT_AMOUNT, lastNonce + 1, sessionId);
 
         // Attempt to redeem with the wrong payee
-        // Revert with ChannelDoesNotExistOrWithdrawn error 
+        // Revert with ChannelDoesNotExistOrWithdrawn error
         // since channel between PAYEE2 and PAYER does not exist
         vm.expectRevert(abi.encodeWithSignature("ChannelDoesNotExistOrWithdrawn()"));
         multisig.redeemChannel(PAYER, NATIVE_TOKEN, DEPOSIT_AMOUNT, lastNonce + 1, signature);

--- a/test/multisig/RedeemChannel.t.sol
+++ b/test/multisig/RedeemChannel.t.sol
@@ -1,25 +1,197 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.28;
+pragma solidity ^0.8.28;
 
 import {Test, console} from "forge-std/Test.sol";
 import {Multisig} from "../../src/Multisig_2of2.sol";
+import {BaseTestHelper} from "../helper/BaseTestHelper.sol";
+import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
-contract RedeemChannelTest is Test {
-    Multisig multisig;
-    address payer = address(0x1);
-    address payee = address(0x2);
-    address token = address(0); // native ETH
-    uint256 amount = 1000;
-    uint64 duration = 100;
-    uint64 reclaimDelay = 200;
+contract RedeemChannelTest is Test, BaseTestHelper {
+    Multisig public multisig;
+
+    using MessageHashUtils for bytes32;
 
     function setUp() public {
-        multisig = new Multisig();
-        vm.deal(payer, 10 * amount);
+        setUpNativeTokenWithCreateChannel();
+    }
 
-        // Payer creates channel
-        vm.startPrank(payer);
-        multisig.createChannel{value: amount}(payee, address(0), amount, duration, reclaimDelay);
+    function setUpNativeToken() public {
+        vm.startPrank(OWNER);
+        multisig = new Multisig();
         vm.stopPrank();
+        vm.deal(PAYER, INITIAL_BALANCE);
+        vm.deal(PAYER2, INITIAL_BALANCE);
+    }
+
+    function setUpNativeTokenWithCreateChannel() public {
+        setUpNativeToken();
+        vm.startPrank(PAYER);
+        multisig.createChannel{value: DEPOSIT_AMOUNT}(PAYEE, NATIVE_TOKEN, DEPOSIT_AMOUNT, DURATION, RECLAIM_DELAY);
+        vm.stopPrank();
+    }
+
+    function getSignature(
+        address contractAddress,
+        uint256 payerPk,
+        address payee,
+        address depositToken,
+        uint256 amount,
+        uint256 nonce,
+        uint64 sessionId
+    ) public pure returns (bytes memory signature) {
+        address payer = vm.addr(payerPk);
+        // Create the hash to sign
+        bytes32 hash =
+            keccak256(abi.encodePacked(contractAddress, payer, payee, depositToken, amount, nonce, sessionId));
+        bytes32 messageHash = hash.toEthSignedMessageHash();
+        // Sign the hash with the payer's private key
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(payerPk, messageHash);
+        signature = abi.encodePacked(r, s, v);
+    }
+
+    function testMultisigRedeemChannelWithNativeToken() public {
+        uint256 contractBalanceBefore = address(multisig).balance;
+        uint256 payeeBalanceBefore = PAYEE.balance;
+        vm.startPrank(PAYEE);
+        (,,,, uint64 sessionId, uint256 lastNonce) = multisig.channels(PAYER, PAYEE, NATIVE_TOKEN);
+        bytes memory signature =
+            getSignature(address(multisig), PAYER1PK, PAYEE, NATIVE_TOKEN, DEPOSIT_AMOUNT, lastNonce + 1, sessionId);
+
+        multisig.redeemChannel(PAYER, NATIVE_TOKEN, DEPOSIT_AMOUNT, lastNonce + 1, signature);
+        vm.stopPrank();
+
+        // Verify channel redeemed
+        (address channelToken, uint256 channelAmount,,,,) = multisig.channels(PAYER, PAYEE, NATIVE_TOKEN);
+        assertEq(channelToken, NATIVE_TOKEN, "channel token should be zero address for native token");
+        assertEq(channelAmount, 0, "channel amount should be zero after redeem");
+        assertEq(
+            address(multisig).balance,
+            contractBalanceBefore - DEPOSIT_AMOUNT,
+            "contract balance should decrease by deposit amount"
+        );
+        assertEq(PAYEE.balance, payeeBalanceBefore + DEPOSIT_AMOUNT, "payee balance should increase by deposit amount");
+    }
+
+    function testMultisigCannotRedeemWithInvalidSignature() public {
+        uint256 contractBalanceBefore = address(multisig).balance;
+        uint256 payeeBalanceBefore = PAYEE.balance;
+        vm.startPrank(PAYEE);
+        (,,,, uint64 sessionId, uint256 lastNonce) = multisig.channels(PAYER, PAYEE, NATIVE_TOKEN);
+        bytes memory signature =
+            getSignature(address(multisig), PAYER2PK, PAYEE, NATIVE_TOKEN, DEPOSIT_AMOUNT, lastNonce + 1, sessionId);
+
+        // Attempt to redeem with an invalid signature
+        // Expect revert with InvalidChannelSignature error
+        vm.expectRevert();
+        multisig.redeemChannel(PAYER, NATIVE_TOKEN, DEPOSIT_AMOUNT, lastNonce + 1, signature);
+        vm.stopPrank();
+
+        // Verify channel state remains unchanged
+        _assertChannelStateWhenFailedRedeem(
+            contractBalanceBefore, payeeBalanceBefore, address(multisig).balance, PAYEE.balance
+        );
+    }
+
+    function testMultisigCannotRedeemAfterExpiration() public {
+        (,,,, uint64 sessionId, uint256 lastNonce) = multisig.channels(PAYER, PAYEE, NATIVE_TOKEN);
+        bytes memory signature =
+            getSignature(address(multisig), PAYER1PK, PAYEE, NATIVE_TOKEN, DEPOSIT_AMOUNT, lastNonce + 1, sessionId);
+        (,,uint64 expiration,,,) = multisig.channels(PAYER, PAYEE, NATIVE_TOKEN);
+        vm.warp(expiration + 1); // Move time past expiration
+
+        vm.startPrank(PAYEE);
+        // Attempt to redeem after expiration
+        vm.expectRevert(abi.encodeWithSignature("ChannelExpired(uint64)", expiration));
+        multisig.redeemChannel(PAYER, NATIVE_TOKEN, DEPOSIT_AMOUNT, lastNonce + 1, signature);
+        vm.stopPrank();
+    }
+
+    function testsMultisigCannotRedeemWithIncorrectAmountHigher() public {
+        uint256 contractBalanceBefore = address(multisig).balance;
+        uint256 payeeBalanceBefore = PAYEE.balance;
+        vm.startPrank(PAYEE);
+        (,,,, uint64 sessionId, uint256 lastNonce) = multisig.channels(PAYER, PAYEE, NATIVE_TOKEN);
+        bytes memory signature =
+            getSignature(address(multisig), PAYER1PK, PAYEE, NATIVE_TOKEN, DEPOSIT_AMOUNT + 1, lastNonce + 1, sessionId);
+
+        // Attempt to redeem with an incorrect amount
+        vm.expectRevert(abi.encodeWithSignature("IncorrectAmount(uint256,uint256)", DEPOSIT_AMOUNT + 1, DEPOSIT_AMOUNT));
+        multisig.redeemChannel(PAYER, NATIVE_TOKEN, DEPOSIT_AMOUNT + 1, lastNonce + 1, signature);
+        vm.stopPrank();
+
+        // Verify channel state remains unchanged
+        _assertChannelStateWhenFailedRedeem(
+            contractBalanceBefore, payeeBalanceBefore, address(multisig).balance, PAYEE.balance
+        );
+    }
+
+    function testMultisigCannotRedeemWIthStaleNonce() public {
+        uint256 contractBalanceBefore = address(multisig).balance;
+        uint256 payeeBalanceBefore = PAYEE.balance;
+        vm.startPrank(PAYEE);
+        (,,,, uint64 sessionId, uint256 lastNonce) = multisig.channels(PAYER, PAYEE, NATIVE_TOKEN);
+        bytes memory signature =
+            getSignature(address(multisig), PAYER1PK, PAYEE, NATIVE_TOKEN, DEPOSIT_AMOUNT, lastNonce - 1, sessionId);
+
+        // Attempt to redeem with a stale nonce
+        vm.expectRevert(abi.encodeWithSignature("StaleNonce(uint256,uint256)", lastNonce - 1, lastNonce));
+        multisig.redeemChannel(PAYER, NATIVE_TOKEN, DEPOSIT_AMOUNT, lastNonce - 1, signature);
+        vm.stopPrank();
+
+        // Verify channel state remains unchanged
+        _assertChannelStateWhenFailedRedeem(
+            contractBalanceBefore, payeeBalanceBefore, address(multisig).balance, PAYEE.balance
+        );
+    }
+
+    function testMultisigCannotRedeemChannelDoesNotExist() public {
+        uint256 contractBalanceBefore = address(multisig).balance;
+        uint256 payeeBalanceBefore = PAYEE.balance;
+        vm.startPrank(PAYEE);
+        bytes memory signature =
+            getSignature(address(multisig), PAYER2PK, PAYEE, NATIVE_TOKEN, DEPOSIT_AMOUNT, 1, 1);
+
+        // Attempt to redeem a channel that does not exist
+        vm.expectRevert(abi.encodeWithSignature("ChannelDoesNotExistOrWithdrawn()"));
+        multisig.redeemChannel(PAYER2, NATIVE_TOKEN, DEPOSIT_AMOUNT, 1, signature);
+        vm.stopPrank();
+
+        // Verify channel state remains unchanged
+        _assertChannelStateWhenFailedRedeem(
+            contractBalanceBefore, payeeBalanceBefore, address(multisig).balance, PAYEE.balance
+        );
+    }
+
+    function testMultisigCannotRedeemFromWrongPayee() public {
+        uint256 contractBalanceBefore = address(multisig).balance;
+        uint256 payeeBalanceBefore = PAYEE.balance;
+        vm.startPrank(PAYER2); // PAYER2 tries to redeem
+        (,,,, uint64 sessionId, uint256 lastNonce) = multisig.channels(PAYER, PAYEE, NATIVE_TOKEN);
+        bytes memory signature =
+            getSignature(address(multisig), PAYER1PK, PAYEE, NATIVE_TOKEN, DEPOSIT_AMOUNT, lastNonce + 1, sessionId);
+
+        // Attempt to redeem with the wrong payee
+        // Revert with ChannelDoesNotExistOrWithdrawn error 
+        // since channel between PAYEE2 and PAYER does not exist
+        vm.expectRevert(abi.encodeWithSignature("ChannelDoesNotExistOrWithdrawn()"));
+        multisig.redeemChannel(PAYER, NATIVE_TOKEN, DEPOSIT_AMOUNT, lastNonce + 1, signature);
+        vm.stopPrank();
+
+        // Verify channel state remains unchanged
+        _assertChannelStateWhenFailedRedeem(
+            contractBalanceBefore, payeeBalanceBefore, address(multisig).balance, PAYEE.balance
+        );
+    }
+
+    function _assertChannelStateWhenFailedRedeem(
+        uint256 contractBalanceBefore,
+        uint256 payeeBalanceBefore,
+        uint256 contractBalanceAfter,
+        uint256 payeeBalanceAfter
+    ) internal pure {
+        assertEq(
+            contractBalanceAfter, contractBalanceBefore, "contract balance should remain unchanged after failed redeem"
+        );
+        assertEq(payeeBalanceAfter, payeeBalanceBefore, "payee balance should remain unchanged after failed redeem");
     }
 }


### PR DESCRIPTION
## Features

- Implemented `Multisig_2of2.sol` with support for native and ERC20 payment channels.
- Added core functions: `createChannel`, `redeemChannel`, and `reclaimChannel`.

## Tests

- Added base test helpers to streamline multisig test setup.
- Comprehensive test coverage for `createChannel`, `redeemChannel`, and `reclaimChannel` logic.

## Chores

- Updated Solidity version across contracts and scripts to `^0.8.28`.
- Updated `foundry.toml` with new solc version (`0.8.30`) and formatting fixes.